### PR TITLE
Log errors returned by OpenPlatform

### DIFF
--- a/app/SearchOpenPlatform.php
+++ b/app/SearchOpenPlatform.php
@@ -5,19 +5,23 @@ namespace App;
 use App\Contracts\Searcher;
 use DDB\OpenPlatform\OpenPlatform;
 use Illuminate\Support\Carbon;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 class SearchOpenPlatform implements Searcher
 {
+    use LoggerAwareTrait;
 
     /**
      * @var \DDB\OpenPlatform\OpenPlatform
      */
     protected $openplatform;
 
-    public function __construct(OpenPlatform $openplatform)
+    public function __construct(OpenPlatform $openplatform, LoggerInterface $logger)
     {
         $this->openplatform = $openplatform;
+        $this->logger = $logger;
     }
 
     /**
@@ -40,6 +44,7 @@ class SearchOpenPlatform implements Searcher
             try {
                 $results[$id] = $res->getHitCount();
             } catch (Throwable $e) {
+                $this->logger->error($e->getMessage());
                 $results[$id] = 0;
             }
         }
@@ -64,6 +69,7 @@ class SearchOpenPlatform implements Searcher
                 ];
             }
         } catch (Throwable $e) {
+            $this->logger->error($e->getMessage());
             return [];
         }
         return $result;


### PR DESCRIPTION
Currently we do not provide any feedback to callers if a response
contains an error and no other signal is provided.

We do not have a proper way to communicate errors relating to a
single search to the client so the current behavior of returning no
new results make sense. However shallowing exceptions entirely makes
it impossible to know if anything has gone wrong.

This PR adds some logging to ensure that errors are at least picked
up somewhere.

Update tests accordingly.