### PR TITLE
Fix adding of CORS headers

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -54,6 +54,11 @@ $app->singleton(
 | route or middleware that'll be assigned to some specific routes.
 |
 */
+$app->configure('cors');
+
+$app->middleware([
+    Spatie\Cors\Cors::class,
+]);
 
 // $app->routeMiddleware([
 //     'auth' => App\Http\Middleware\Authenticate::class,
@@ -71,6 +76,7 @@ $app->singleton(
 */
 
 $app->register(\Adgangsplatformen\Support\Illuminate\AdgangsplatformenServiceProvider::class);
+$app->register(\Spatie\Cors\CorsServiceProvider::class);
 $app->register(\App\Providers\AppServiceProvider::class);
 $app->register(\DDB\Stats\ServiceProviders\StatisticsServiceProvider::class);
 $app->register(\App\Providers\EventServiceProvider::class);


### PR DESCRIPTION
The package needs to be configured, middleware added and
serviceprovider added for it to work.

Try to compare #36 with reload/material-list#40 and you can tell this is missing.