### PR TITLE
Fix handling of query added multiple times

### DIFF
--- a/app/Http/Controllers/SearchesController.php
+++ b/app/Http/Controllers/SearchesController.php
@@ -82,12 +82,12 @@ class SearchesController extends Controller
             ->updateOrInsert(
                 [
                     'guid' => $request->user()->getId(),
-                    'list' => $listName,
-                    'title' => $request->get('title'),
-                    'query' => $request->get('query'),
                     'hash' => hash('sha512', $request->get('query')),
                 ],
                 [
+                    'list' => $listName,
+                    'title' => $request->get('title'),
+                    'query' => $request->get('query'),
                     // We need to format the date ourselves to add microseconds.
                     'changed_at' => Carbon::now()->format('Y-m-d H:i:s.u'),
                     'last_seen' => Carbon::now()

--- a/tests/features/add_to_searches.feature
+++ b/tests/features/add_to_searches.feature
@@ -21,7 +21,7 @@ Feature: Add to searches list
     Then the system should return success
     And search "terry pratchett" should be on the list with title "Terry"
 
-  Scenario: Materials should only be added once
+  Scenario: Searches should only be added once
     Given a known user
     And they have the following items on the list:
       | title | query        | last_seen           |

--- a/tests/features/add_to_searches.feature
+++ b/tests/features/add_to_searches.feature
@@ -32,3 +32,15 @@ Feature: Add to searches list
     And fetching searches should return:
       | title | query        | last_seen           |
       | Harry | harry potter | 2019-10-02 10:00:00 |
+
+  Scenario: Adding a query multiple times updates the title.
+    Given a known user
+    And they have the following items on the list:
+      | title | query        | last_seen           |
+      | Harry | harry potter | 2019-10-02 10:00:00 |
+    And the time is "2019-10-02 10:00"
+    When search "harry potter" with title "Wizards" is added to the list
+    Then the system should return success
+    And fetching searches should return:
+      | title   | query        | last_seen           |
+      | Wizards | harry potter | 2019-10-02 10:00:00 |


### PR DESCRIPTION
Our current model is based on the query being unique for the user.
However if a query is added multiple times the service will return
an error due to an unique constraint violation.

We expected this to be handled by using updateOrInsert in combination
with our unique index. However the query builder will actually query
for the existence of our attributes (first paramater) and based on
that determine if attributes *and* values (2nd parameter) should be
inserted or updated.

Consequently we move elements which are not part of the unique index
from attributes to values.

We also add a test case which covers this scenario.